### PR TITLE
Refactor OPD module documentation and enhance API key management

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 MISTRAL_API_KEY = 6mRyKcFnuBrKlfEsfFwMZVlQZZqWWZHB
+JINA_API_KEY = jina_ac73bf89d19b4515ae79dbddbe0659b9Pe2yo-PHGws_4D_uoi5xJ_OzQ-3A
 CEREBRAS_API_KEY = csk-j3jrt6y3jjje5ycvx5m3y8xpr9hk98d2fjttdwm446v4t2dd
 CEREBRAS_API_KEY_OLD = csk-r6wv8fnrwy38rx8ky8kc33x5f58tp6dekhxp2xkcnxnwfmej
 DATABASE_CONNECTION_STRING = postgresql://hmisdev:hmis%40railtel@192.168.169.228:5432/datasets

--- a/.vscode/PythonImportHelper-v2-Completion.json
+++ b/.vscode/PythonImportHelper-v2-Completion.json
@@ -136,6 +136,22 @@
         "documentation": {}
     },
     {
+        "label": "ABC",
+        "importPath": "abc",
+        "description": "abc",
+        "isExtraImport": true,
+        "detail": "abc",
+        "documentation": {}
+    },
+    {
+        "label": "abstractmethod",
+        "importPath": "abc",
+        "description": "abc",
+        "isExtraImport": true,
+        "detail": "abc",
+        "documentation": {}
+    },
+    {
         "label": "StreamingResponse",
         "importPath": "fastapi.responses",
         "description": "fastapi.responses",
@@ -177,66 +193,66 @@
     },
     {
         "label": "ChatServiceRequestModel",
-        "importPath": "clientservices.cerebras.models",
-        "description": "clientservices.cerebras.models",
+        "importPath": "clientservices.chat.models",
+        "description": "clientservices.chat.models",
         "isExtraImport": true,
-        "detail": "clientservices.cerebras.models",
+        "detail": "clientservices.chat.models",
         "documentation": {}
     },
     {
         "label": "ChatServiceResponseModel",
-        "importPath": "clientservices.cerebras.models",
-        "description": "clientservices.cerebras.models",
+        "importPath": "clientservices.chat.models",
+        "description": "clientservices.chat.models",
         "isExtraImport": true,
-        "detail": "clientservices.cerebras.models",
+        "detail": "clientservices.chat.models",
         "documentation": {}
     },
     {
         "label": "ChatServiceRequestModel",
-        "importPath": "clientservices.cerebras.models",
-        "description": "clientservices.cerebras.models",
+        "importPath": "clientservices.chat.models",
+        "description": "clientservices.chat.models",
         "isExtraImport": true,
-        "detail": "clientservices.cerebras.models",
+        "detail": "clientservices.chat.models",
         "documentation": {}
     },
     {
         "label": "ChatServiceResponseModel",
-        "importPath": "clientservices.cerebras.models",
-        "description": "clientservices.cerebras.models",
+        "importPath": "clientservices.chat.models",
+        "description": "clientservices.chat.models",
         "isExtraImport": true,
-        "detail": "clientservices.cerebras.models",
+        "detail": "clientservices.chat.models",
         "documentation": {}
     },
     {
         "label": "ChatServiceDataResponseModel",
-        "importPath": "clientservices.cerebras.models",
-        "description": "clientservices.cerebras.models",
+        "importPath": "clientservices.chat.models",
+        "description": "clientservices.chat.models",
         "isExtraImport": true,
-        "detail": "clientservices.cerebras.models",
+        "detail": "clientservices.chat.models",
         "documentation": {}
     },
     {
         "label": "ChatServiceUsageModel",
-        "importPath": "clientservices.cerebras.models",
-        "description": "clientservices.cerebras.models",
+        "importPath": "clientservices.chat.models",
+        "description": "clientservices.chat.models",
         "isExtraImport": true,
-        "detail": "clientservices.cerebras.models",
+        "detail": "clientservices.chat.models",
         "documentation": {}
     },
     {
         "label": "ChatServiceChoiceModel",
-        "importPath": "clientservices.cerebras.models",
-        "description": "clientservices.cerebras.models",
+        "importPath": "clientservices.chat.models",
+        "description": "clientservices.chat.models",
         "isExtraImport": true,
-        "detail": "clientservices.cerebras.models",
+        "detail": "clientservices.chat.models",
         "documentation": {}
     },
     {
         "label": "ChatServiceChoiceMessageModel",
-        "importPath": "clientservices.cerebras.models",
-        "description": "clientservices.cerebras.models",
+        "importPath": "clientservices.chat.models",
+        "description": "clientservices.chat.models",
         "isExtraImport": true,
-        "detail": "clientservices.cerebras.models",
+        "detail": "clientservices.chat.models",
         "documentation": {}
     },
     {
@@ -328,6 +344,14 @@
         "documentation": {}
     },
     {
+        "label": "Any",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
         "label": "cast",
         "importPath": "typing",
         "description": "typing",
@@ -337,6 +361,14 @@
     },
     {
         "label": "Any",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "cast",
         "importPath": "typing",
         "description": "typing",
         "isExtraImport": true,
@@ -496,27 +528,51 @@
         "documentation": {}
     },
     {
+        "label": "BaseModel",
+        "importPath": "pydantic",
+        "description": "pydantic",
+        "isExtraImport": true,
+        "detail": "pydantic",
+        "documentation": {}
+    },
+    {
         "label": "ChatServiceMessageRoleEnum",
-        "importPath": "clientservices.cerebras.enums",
-        "description": "clientservices.cerebras.enums",
+        "importPath": "clientservices.chat.enums",
+        "description": "clientservices.chat.enums",
         "isExtraImport": true,
-        "detail": "clientservices.cerebras.enums",
+        "detail": "clientservices.chat.enums",
         "documentation": {}
     },
     {
         "label": "ChatServiceResponseStatusEnum",
-        "importPath": "clientservices.cerebras.enums",
-        "description": "clientservices.cerebras.enums",
+        "importPath": "clientservices.chat.enums",
+        "description": "clientservices.chat.enums",
         "isExtraImport": true,
-        "detail": "clientservices.cerebras.enums",
+        "detail": "clientservices.chat.enums",
         "documentation": {}
     },
     {
         "label": "ChatServiceResponseStatusEnum",
-        "importPath": "clientservices.cerebras.enums",
-        "description": "clientservices.cerebras.enums",
+        "importPath": "clientservices.chat.enums",
+        "description": "clientservices.chat.enums",
         "isExtraImport": true,
-        "detail": "clientservices.cerebras.enums",
+        "detail": "clientservices.chat.enums",
+        "documentation": {}
+    },
+    {
+        "label": "ChatServiceResponseStatusEnum",
+        "importPath": "clientservices.chat.enums",
+        "description": "clientservices.chat.enums",
+        "isExtraImport": true,
+        "detail": "clientservices.chat.enums",
+        "documentation": {}
+    },
+    {
+        "label": "ChatServiceResponseStatusEnum",
+        "importPath": "clientservices.chat.enums",
+        "description": "clientservices.chat.enums",
+        "isExtraImport": true,
+        "detail": "clientservices.chat.enums",
         "documentation": {}
     },
     {
@@ -546,18 +602,18 @@
     },
     {
         "label": "ChatServiceImpl",
-        "importPath": "clientservices.cerebras.implementations",
-        "description": "clientservices.cerebras.implementations",
+        "importPath": "clientservices.chat.implementations",
+        "description": "clientservices.chat.implementations",
         "isExtraImport": true,
-        "detail": "clientservices.cerebras.implementations",
+        "detail": "clientservices.chat.implementations",
         "documentation": {}
     },
     {
         "label": "GetCerebrasApiKey",
-        "importPath": "clientservices.cerebras.workers",
-        "description": "clientservices.cerebras.workers",
+        "importPath": "clientservices.chat.workers",
+        "description": "clientservices.chat.workers",
         "isExtraImport": true,
-        "detail": "clientservices.cerebras.workers",
+        "detail": "clientservices.chat.workers",
         "documentation": {}
     },
     {
@@ -603,130 +659,178 @@
     },
     {
         "label": "EmbeddingResponseModel",
-        "importPath": "clientservices.mistral.models",
-        "description": "clientservices.mistral.models",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.models",
+        "detail": "clientservices.embedding.models",
         "documentation": {}
     },
     {
         "label": "MistralChatResponseModel",
-        "importPath": "clientservices.mistral.models",
-        "description": "clientservices.mistral.models",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.models",
+        "detail": "clientservices.embedding.models",
         "documentation": {}
     },
     {
         "label": "MistralChatRequestModel",
-        "importPath": "clientservices.mistral.models",
-        "description": "clientservices.mistral.models",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.models",
+        "detail": "clientservices.embedding.models",
+        "documentation": {}
+    },
+    {
+        "label": "RerankingRequestModel",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
+        "isExtraImport": true,
+        "detail": "clientservices.embedding.models",
+        "documentation": {}
+    },
+    {
+        "label": "RerankingResponseModel",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
+        "isExtraImport": true,
+        "detail": "clientservices.embedding.models",
         "documentation": {}
     },
     {
         "label": "EmbeddingResponseModel",
-        "importPath": "clientservices.mistral.models",
-        "description": "clientservices.mistral.models",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.models",
+        "detail": "clientservices.embedding.models",
         "documentation": {}
     },
     {
         "label": "EmbeddingDataModel",
-        "importPath": "clientservices.mistral.models",
-        "description": "clientservices.mistral.models",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.models",
+        "detail": "clientservices.embedding.models",
         "documentation": {}
     },
     {
         "label": "EmbeddingUsageModel",
-        "importPath": "clientservices.mistral.models",
-        "description": "clientservices.mistral.models",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.models",
+        "detail": "clientservices.embedding.models",
         "documentation": {}
     },
     {
         "label": "MistralChatResponseModel",
-        "importPath": "clientservices.mistral.models",
-        "description": "clientservices.mistral.models",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.models",
+        "detail": "clientservices.embedding.models",
         "documentation": {}
     },
     {
         "label": "MistralChatResponseUsageModel",
-        "importPath": "clientservices.mistral.models",
-        "description": "clientservices.mistral.models",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.models",
+        "detail": "clientservices.embedding.models",
         "documentation": {}
     },
     {
         "label": "MistralChatResponseChoiceModel",
-        "importPath": "clientservices.mistral.models",
-        "description": "clientservices.mistral.models",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.models",
+        "detail": "clientservices.embedding.models",
         "documentation": {}
     },
     {
         "label": "MistralChatResponseMessageModel",
-        "importPath": "clientservices.mistral.models",
-        "description": "clientservices.mistral.models",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.models",
+        "detail": "clientservices.embedding.models",
         "documentation": {}
     },
     {
         "label": "MistralChatRequestModel",
-        "importPath": "clientservices.mistral.models",
-        "description": "clientservices.mistral.models",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.models",
+        "detail": "clientservices.embedding.models",
+        "documentation": {}
+    },
+    {
+        "label": "RerankingRequestModel",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
+        "isExtraImport": true,
+        "detail": "clientservices.embedding.models",
+        "documentation": {}
+    },
+    {
+        "label": "RerankingResponseModel",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
+        "isExtraImport": true,
+        "detail": "clientservices.embedding.models",
+        "documentation": {}
+    },
+    {
+        "label": "RerankingResponseChoiseModel",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
+        "isExtraImport": true,
+        "detail": "clientservices.embedding.models",
+        "documentation": {}
+    },
+    {
+        "label": "RerankingUsageModel",
+        "importPath": "clientservices.embedding.models",
+        "description": "clientservices.embedding.models",
+        "isExtraImport": true,
+        "detail": "clientservices.embedding.models",
         "documentation": {}
     },
     {
         "label": "MistralChatMessageRoleEnum",
-        "importPath": "clientservices.mistral.enums",
-        "description": "clientservices.mistral.enums",
+        "importPath": "clientservices.embedding.enums",
+        "description": "clientservices.embedding.enums",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.enums",
+        "detail": "clientservices.embedding.enums",
         "documentation": {}
     },
     {
         "label": "MistralChatResponseStatusEnum",
-        "importPath": "clientservices.mistral.enums",
-        "description": "clientservices.mistral.enums",
+        "importPath": "clientservices.embedding.enums",
+        "description": "clientservices.embedding.enums",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.enums",
+        "detail": "clientservices.embedding.enums",
         "documentation": {}
     },
     {
         "label": "EmbeddingResponseEnum",
-        "importPath": "clientservices.mistral.enums",
-        "description": "clientservices.mistral.enums",
+        "importPath": "clientservices.embedding.enums",
+        "description": "clientservices.embedding.enums",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.enums",
+        "detail": "clientservices.embedding.enums",
         "documentation": {}
     },
     {
         "label": "EmbeddingResponseEnum",
-        "importPath": "clientservices.mistral.enums",
-        "description": "clientservices.mistral.enums",
+        "importPath": "clientservices.embedding.enums",
+        "description": "clientservices.embedding.enums",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.enums",
+        "detail": "clientservices.embedding.enums",
         "documentation": {}
     },
     {
         "label": "MistralChatResponseStatusEnum",
-        "importPath": "clientservices.mistral.enums",
-        "description": "clientservices.mistral.enums",
+        "importPath": "clientservices.embedding.enums",
+        "description": "clientservices.embedding.enums",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.enums",
+        "detail": "clientservices.embedding.enums",
         "documentation": {}
     },
     {
@@ -770,27 +874,133 @@
         "documentation": {}
     },
     {
-        "label": "GetMistralApiKey",
-        "importPath": "clientservices.mistral.workers",
-        "description": "clientservices.mistral.workers",
+        "label": "EmbeddingServiceImpl",
+        "importPath": "clientservices.embedding.implementations",
+        "description": "clientservices.embedding.implementations",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.workers",
-        "documentation": {}
-    },
-    {
-        "label": "GetMistralApiKey",
-        "importPath": "clientservices.mistral.workers",
-        "description": "clientservices.mistral.workers",
-        "isExtraImport": true,
-        "detail": "clientservices.mistral.workers",
+        "detail": "clientservices.embedding.implementations",
         "documentation": {}
     },
     {
         "label": "MistralChatImpl",
-        "importPath": "clientservices.mistral.implementations",
-        "description": "clientservices.mistral.implementations",
+        "importPath": "clientservices.embedding.implementations",
+        "description": "clientservices.embedding.implementations",
         "isExtraImport": true,
-        "detail": "clientservices.mistral.implementations",
+        "detail": "clientservices.embedding.implementations",
+        "documentation": {}
+    },
+    {
+        "label": "RerankingImpl",
+        "importPath": "clientservices.embedding.implementations",
+        "description": "clientservices.embedding.implementations",
+        "isExtraImport": true,
+        "detail": "clientservices.embedding.implementations",
+        "documentation": {}
+    },
+    {
+        "label": "GetMistralApiKey",
+        "importPath": "clientservices.embedding.workers",
+        "description": "clientservices.embedding.workers",
+        "isExtraImport": true,
+        "detail": "clientservices.embedding.workers",
+        "documentation": {}
+    },
+    {
+        "label": "GetMistralApiKey",
+        "importPath": "clientservices.embedding.workers",
+        "description": "clientservices.embedding.workers",
+        "isExtraImport": true,
+        "detail": "clientservices.embedding.workers",
+        "documentation": {}
+    },
+    {
+        "label": "GetJinaApiKey",
+        "importPath": "clientservices.embedding.workers",
+        "description": "clientservices.embedding.workers",
+        "isExtraImport": true,
+        "detail": "clientservices.embedding.workers",
+        "documentation": {}
+    },
+    {
+        "label": "numpy",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "numpy",
+        "description": "numpy",
+        "detail": "numpy",
+        "documentation": {}
+    },
+    {
+        "label": "requests",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "requests",
+        "description": "requests",
+        "detail": "requests",
+        "documentation": {}
+    },
+    {
+        "label": "HandleChunkRelationExtractResponseModel",
+        "importPath": "graphrag.models",
+        "description": "graphrag.models",
+        "isExtraImport": true,
+        "detail": "graphrag.models",
+        "documentation": {}
+    },
+    {
+        "label": "ChunkRelationsModel",
+        "importPath": "graphrag.models",
+        "description": "graphrag.models",
+        "isExtraImport": true,
+        "detail": "graphrag.models",
+        "documentation": {}
+    },
+    {
+        "label": "ChunkTextsModel",
+        "importPath": "graphrag.models",
+        "description": "graphrag.models",
+        "isExtraImport": true,
+        "detail": "graphrag.models",
+        "documentation": {}
+    },
+    {
+        "label": "ChunkRelationModel",
+        "importPath": "graphrag.models",
+        "description": "graphrag.models",
+        "isExtraImport": true,
+        "detail": "graphrag.models",
+        "documentation": {}
+    },
+    {
+        "label": "HandleChunkRelationExtractResponseModel",
+        "importPath": "graphrag.models",
+        "description": "graphrag.models",
+        "isExtraImport": true,
+        "detail": "graphrag.models",
+        "documentation": {}
+    },
+    {
+        "label": "ChunkNodeModel",
+        "importPath": "graphrag.models",
+        "description": "graphrag.models",
+        "isExtraImport": true,
+        "detail": "graphrag.models",
+        "documentation": {}
+    },
+    {
+        "label": "AllRelationsModel",
+        "importPath": "graphrag.models",
+        "description": "graphrag.models",
+        "isExtraImport": true,
+        "detail": "graphrag.models",
+        "documentation": {}
+    },
+    {
+        "label": "UUID",
+        "importPath": "uuid",
+        "description": "uuid",
+        "isExtraImport": true,
+        "detail": "uuid",
         "documentation": {}
     },
     {
@@ -831,14 +1041,6 @@
         "description": "uuid",
         "isExtraImport": true,
         "detail": "uuid",
-        "documentation": {}
-    },
-    {
-        "label": "text",
-        "importPath": "pydoc",
-        "description": "pydoc",
-        "isExtraImport": true,
-        "detail": "pydoc",
         "documentation": {}
     },
     {
@@ -940,6 +1142,30 @@
         "documentation": {}
     },
     {
+        "label": "RerankingService",
+        "importPath": "clientservices",
+        "description": "clientservices",
+        "isExtraImport": true,
+        "detail": "clientservices",
+        "documentation": {}
+    },
+    {
+        "label": "RerankingRequestModel",
+        "importPath": "clientservices",
+        "description": "clientservices",
+        "isExtraImport": true,
+        "detail": "clientservices",
+        "documentation": {}
+    },
+    {
+        "label": "RerankingResponseModel",
+        "importPath": "clientservices",
+        "description": "clientservices",
+        "isExtraImport": true,
+        "detail": "clientservices",
+        "documentation": {}
+    },
+    {
         "label": "ChatServiceResponseStatusEnum",
         "importPath": "clientservices",
         "description": "clientservices",
@@ -1100,6 +1326,14 @@
         "documentation": {}
     },
     {
+        "label": "RerankingService",
+        "importPath": "clientservices",
+        "description": "clientservices",
+        "isExtraImport": true,
+        "detail": "clientservices",
+        "documentation": {}
+    },
+    {
         "label": "FileChunkGragImpl",
         "importPath": "graphrag.implementations",
         "description": "graphrag.implementations",
@@ -1133,10 +1367,10 @@
     },
     {
         "label": "ExtractEntityGragSystemPrompt",
-        "importPath": "graphrag.utils.GragSystemPropts",
-        "description": "graphrag.utils.GragSystemPropts",
+        "importPath": "graphrag.utils.FileGragSystemPropts",
+        "description": "graphrag.utils.FileGragSystemPropts",
         "isExtraImport": true,
-        "detail": "graphrag.utils.GragSystemPropts",
+        "detail": "graphrag.utils.FileGragSystemPropts",
         "documentation": {}
     },
     {
@@ -1146,38 +1380,6 @@
         "importPath": "json",
         "description": "json",
         "detail": "json",
-        "documentation": {}
-    },
-    {
-        "label": "ChunkRelationsModel",
-        "importPath": "graphrag.models",
-        "description": "graphrag.models",
-        "isExtraImport": true,
-        "detail": "graphrag.models",
-        "documentation": {}
-    },
-    {
-        "label": "ChunkTextsModel",
-        "importPath": "graphrag.models",
-        "description": "graphrag.models",
-        "isExtraImport": true,
-        "detail": "graphrag.models",
-        "documentation": {}
-    },
-    {
-        "label": "ChunkEntitiesModel",
-        "importPath": "graphrag.models",
-        "description": "graphrag.models",
-        "isExtraImport": true,
-        "detail": "graphrag.models",
-        "documentation": {}
-    },
-    {
-        "label": "ChunkRelationModel",
-        "importPath": "graphrag.models",
-        "description": "graphrag.models",
-        "isExtraImport": true,
-        "detail": "graphrag.models",
         "documentation": {}
     },
     {
@@ -1373,15 +1575,6 @@
         "documentation": {}
     },
     {
-        "label": "numpy",
-        "kind": 6,
-        "isExtraImport": true,
-        "importPath": "numpy",
-        "description": "numpy",
-        "detail": "numpy",
-        "documentation": {}
-    },
-    {
         "label": "asyncpg",
         "kind": 6,
         "isExtraImport": true,
@@ -1464,6 +1657,15 @@
         "documentation": {}
     },
     {
+        "label": "time",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "time",
+        "description": "time",
+        "detail": "time",
+        "documentation": {}
+    },
+    {
         "label": "CORSMiddleware",
         "importPath": "fastapi.middleware.cors",
         "description": "fastapi.middleware.cors",
@@ -1506,343 +1708,424 @@
     {
         "label": "ChatServiceMessageRoleEnum",
         "kind": 6,
-        "importPath": "clientservices.cerebras.enums.LLMEnums",
-        "description": "clientservices.cerebras.enums.LLMEnums",
+        "importPath": "clientservices.chat.enums.ChatServiceEnums",
+        "description": "clientservices.chat.enums.ChatServiceEnums",
         "peekOfCode": "class ChatServiceMessageRoleEnum(Enum):\n    USER = \"user\"\n    SYSTEM = \"system\"\n    ASSISTANT = \"assistant\"\nclass ChatServiceResponseStatusEnum(Enum):\n    SUCCESS = (200, \"SUCCESS\")\n    BAD_REQUEST = (400, \"BAD_REQUEST\")\n    UNAUTHROZIED = (401, \"UNAUTHROZIED\")\n    PERMISSION_DENIED = (403, \"PERMISSION_DENIED\")\n    NOT_FOUND = (404, \"NOT_FOUND\")",
-        "detail": "clientservices.cerebras.enums.LLMEnums",
+        "detail": "clientservices.chat.enums.ChatServiceEnums",
         "documentation": {}
     },
     {
         "label": "ChatServiceResponseStatusEnum",
         "kind": 6,
-        "importPath": "clientservices.cerebras.enums.LLMEnums",
-        "description": "clientservices.cerebras.enums.LLMEnums",
+        "importPath": "clientservices.chat.enums.ChatServiceEnums",
+        "description": "clientservices.chat.enums.ChatServiceEnums",
         "peekOfCode": "class ChatServiceResponseStatusEnum(Enum):\n    SUCCESS = (200, \"SUCCESS\")\n    BAD_REQUEST = (400, \"BAD_REQUEST\")\n    UNAUTHROZIED = (401, \"UNAUTHROZIED\")\n    PERMISSION_DENIED = (403, \"PERMISSION_DENIED\")\n    NOT_FOUND = (404, \"NOT_FOUND\")\n    REQUEST_TIMEOUT = (408, \"REQUEST_TIMEOUT\")\n    CONFLICT = (409, \"CONFLICT\")\n    ENTITY_ERROR = (422, \"ENTITY_ERROR\")\n    RATE_LIMIT = (429, \"RATE_LIMIT\")",
-        "detail": "clientservices.cerebras.enums.LLMEnums",
+        "detail": "clientservices.chat.enums.ChatServiceEnums",
         "documentation": {}
     },
     {
         "label": "ChatServiceImpl",
         "kind": 6,
-        "importPath": "clientservices.cerebras.implementations.ChatServiceImplementation",
-        "description": "clientservices.cerebras.implementations.ChatServiceImplementation",
+        "importPath": "clientservices.chat.implementations.ChatServiceImplementation",
+        "description": "clientservices.chat.implementations.ChatServiceImplementation",
         "peekOfCode": "class ChatServiceImpl(ABC):\n    @abstractmethod\n    async def Chat(self, modelParams: ChatServiceRequestModel) -> ChatServiceResponseModel | StreamingResponse:\n        pass\n    @abstractmethod\n    def HandleApiStatusError(\n        self, statusCode: int\n    ) -> ChatServiceResponseModel :\n        pass",
-        "detail": "clientservices.cerebras.implementations.ChatServiceImplementation",
+        "detail": "clientservices.chat.implementations.ChatServiceImplementation",
         "documentation": {}
     },
     {
         "label": "ChatServiceMessageModel",
         "kind": 6,
-        "importPath": "clientservices.cerebras.models.LLMModels",
-        "description": "clientservices.cerebras.models.LLMModels",
+        "importPath": "clientservices.chat.models.ChatServiceModels",
+        "description": "clientservices.chat.models.ChatServiceModels",
         "peekOfCode": "class ChatServiceMessageModel(BaseModel):\n    role: Optional[ChatServiceMessageRoleEnum] = ChatServiceMessageRoleEnum.USER\n    content: str\nclass ChatServiceCerebrasFormatJsonSchemaJsonSchemaPropertyModel(BaseModel):\n    type: str | int | float | str\n    items: Optional[Any] = None\n    properties: Optional[Any] = None\n    required: Optional[Any] = None\n    additionalProperties: Optional[Any] = None\nclass ChatServiceCerebrasFormatJsonSchemaJsonSchemaModel(BaseModel):",
-        "detail": "clientservices.cerebras.models.LLMModels",
+        "detail": "clientservices.chat.models.ChatServiceModels",
         "documentation": {}
     },
     {
         "label": "ChatServiceCerebrasFormatJsonSchemaJsonSchemaPropertyModel",
         "kind": 6,
-        "importPath": "clientservices.cerebras.models.LLMModels",
-        "description": "clientservices.cerebras.models.LLMModels",
+        "importPath": "clientservices.chat.models.ChatServiceModels",
+        "description": "clientservices.chat.models.ChatServiceModels",
         "peekOfCode": "class ChatServiceCerebrasFormatJsonSchemaJsonSchemaPropertyModel(BaseModel):\n    type: str | int | float | str\n    items: Optional[Any] = None\n    properties: Optional[Any] = None\n    required: Optional[Any] = None\n    additionalProperties: Optional[Any] = None\nclass ChatServiceCerebrasFormatJsonSchemaJsonSchemaModel(BaseModel):\n    type: str = \"object\"\n    properties: dict[str, ChatServiceCerebrasFormatJsonSchemaJsonSchemaPropertyModel] = {}\n    required: List[str] = []",
-        "detail": "clientservices.cerebras.models.LLMModels",
+        "detail": "clientservices.chat.models.ChatServiceModels",
         "documentation": {}
     },
     {
         "label": "ChatServiceCerebrasFormatJsonSchemaJsonSchemaModel",
         "kind": 6,
-        "importPath": "clientservices.cerebras.models.LLMModels",
-        "description": "clientservices.cerebras.models.LLMModels",
+        "importPath": "clientservices.chat.models.ChatServiceModels",
+        "description": "clientservices.chat.models.ChatServiceModels",
         "peekOfCode": "class ChatServiceCerebrasFormatJsonSchemaJsonSchemaModel(BaseModel):\n    type: str = \"object\"\n    properties: dict[str, ChatServiceCerebrasFormatJsonSchemaJsonSchemaPropertyModel] = {}\n    required: List[str] = []\n    additionalProperties: bool = False\nclass ChatServiceCerebrasFormatJsonSchemaModel(BaseModel):\n    name: str = \"schema\"\n    strict: bool = True\n    jsonSchema: ChatServiceCerebrasFormatJsonSchemaJsonSchemaModel\nclass ChatServiceCerebrasFormatModel(BaseModel):",
-        "detail": "clientservices.cerebras.models.LLMModels",
+        "detail": "clientservices.chat.models.ChatServiceModels",
         "documentation": {}
     },
     {
         "label": "ChatServiceCerebrasFormatJsonSchemaModel",
         "kind": 6,
-        "importPath": "clientservices.cerebras.models.LLMModels",
-        "description": "clientservices.cerebras.models.LLMModels",
+        "importPath": "clientservices.chat.models.ChatServiceModels",
+        "description": "clientservices.chat.models.ChatServiceModels",
         "peekOfCode": "class ChatServiceCerebrasFormatJsonSchemaModel(BaseModel):\n    name: str = \"schema\"\n    strict: bool = True\n    jsonSchema: ChatServiceCerebrasFormatJsonSchemaJsonSchemaModel\nclass ChatServiceCerebrasFormatModel(BaseModel):\n    type: str = \"json_schema\"\n    jsonSchema: ChatServiceCerebrasFormatJsonSchemaModel\nclass ChatServiceRequestModel(BaseModel):\n    model: str = \"gpt-oss-120b\"\n    messages: List[ChatServiceMessageModel]",
-        "detail": "clientservices.cerebras.models.LLMModels",
+        "detail": "clientservices.chat.models.ChatServiceModels",
         "documentation": {}
     },
     {
         "label": "ChatServiceCerebrasFormatModel",
         "kind": 6,
-        "importPath": "clientservices.cerebras.models.LLMModels",
-        "description": "clientservices.cerebras.models.LLMModels",
+        "importPath": "clientservices.chat.models.ChatServiceModels",
+        "description": "clientservices.chat.models.ChatServiceModels",
         "peekOfCode": "class ChatServiceCerebrasFormatModel(BaseModel):\n    type: str = \"json_schema\"\n    jsonSchema: ChatServiceCerebrasFormatJsonSchemaModel\nclass ChatServiceRequestModel(BaseModel):\n    model: str = \"gpt-oss-120b\"\n    messages: List[ChatServiceMessageModel]\n    maxCompletionTokens: Optional[int] = 20000\n    stream: Optional[bool] = False\n    temperature: Optional[float] = 0.7\n    apiKey: str",
-        "detail": "clientservices.cerebras.models.LLMModels",
+        "detail": "clientservices.chat.models.ChatServiceModels",
         "documentation": {}
     },
     {
         "label": "ChatServiceRequestModel",
         "kind": 6,
-        "importPath": "clientservices.cerebras.models.LLMModels",
-        "description": "clientservices.cerebras.models.LLMModels",
+        "importPath": "clientservices.chat.models.ChatServiceModels",
+        "description": "clientservices.chat.models.ChatServiceModels",
         "peekOfCode": "class ChatServiceRequestModel(BaseModel):\n    model: str = \"gpt-oss-120b\"\n    messages: List[ChatServiceMessageModel]\n    maxCompletionTokens: Optional[int] = 20000\n    stream: Optional[bool] = False\n    temperature: Optional[float] = 0.7\n    apiKey: str\n    responseFormat: Optional[ChatServiceCerebrasFormatModel] = None\nclass ChatServiceChoiceMessageModel(BaseModel):\n    role: ChatServiceMessageRoleEnum = ChatServiceMessageRoleEnum.ASSISTANT",
-        "detail": "clientservices.cerebras.models.LLMModels",
+        "detail": "clientservices.chat.models.ChatServiceModels",
         "documentation": {}
     },
     {
         "label": "ChatServiceChoiceMessageModel",
         "kind": 6,
-        "importPath": "clientservices.cerebras.models.LLMModels",
-        "description": "clientservices.cerebras.models.LLMModels",
+        "importPath": "clientservices.chat.models.ChatServiceModels",
+        "description": "clientservices.chat.models.ChatServiceModels",
         "peekOfCode": "class ChatServiceChoiceMessageModel(BaseModel):\n    role: ChatServiceMessageRoleEnum = ChatServiceMessageRoleEnum.ASSISTANT\n    content: str\nclass ChatServiceChoiceModel(BaseModel):\n    index: int = 0\n    message: ChatServiceChoiceMessageModel\nclass ChatServiceUsageModel(BaseModel):\n    promptTokens: int | None = None\n    completionTokens: int | None = None\n    totalTokens: int | None = None",
-        "detail": "clientservices.cerebras.models.LLMModels",
+        "detail": "clientservices.chat.models.ChatServiceModels",
         "documentation": {}
     },
     {
         "label": "ChatServiceChoiceModel",
         "kind": 6,
-        "importPath": "clientservices.cerebras.models.LLMModels",
-        "description": "clientservices.cerebras.models.LLMModels",
+        "importPath": "clientservices.chat.models.ChatServiceModels",
+        "description": "clientservices.chat.models.ChatServiceModels",
         "peekOfCode": "class ChatServiceChoiceModel(BaseModel):\n    index: int = 0\n    message: ChatServiceChoiceMessageModel\nclass ChatServiceUsageModel(BaseModel):\n    promptTokens: int | None = None\n    completionTokens: int | None = None\n    totalTokens: int | None = None\nclass ChatServiceDataResponseModel(BaseModel):  \n    id: str\n    choices: List[ChatServiceChoiceModel] = []",
-        "detail": "clientservices.cerebras.models.LLMModels",
+        "detail": "clientservices.chat.models.ChatServiceModels",
         "documentation": {}
     },
     {
         "label": "ChatServiceUsageModel",
         "kind": 6,
-        "importPath": "clientservices.cerebras.models.LLMModels",
-        "description": "clientservices.cerebras.models.LLMModels",
+        "importPath": "clientservices.chat.models.ChatServiceModels",
+        "description": "clientservices.chat.models.ChatServiceModels",
         "peekOfCode": "class ChatServiceUsageModel(BaseModel):\n    promptTokens: int | None = None\n    completionTokens: int | None = None\n    totalTokens: int | None = None\nclass ChatServiceDataResponseModel(BaseModel):  \n    id: str\n    choices: List[ChatServiceChoiceModel] = []\n    created: int\n    model: str = \"llama-3.3-70b\"\n    totalTime: float = 0.0",
-        "detail": "clientservices.cerebras.models.LLMModels",
+        "detail": "clientservices.chat.models.ChatServiceModels",
         "documentation": {}
     },
     {
         "label": "ChatServiceDataResponseModel",
         "kind": 6,
-        "importPath": "clientservices.cerebras.models.LLMModels",
-        "description": "clientservices.cerebras.models.LLMModels",
+        "importPath": "clientservices.chat.models.ChatServiceModels",
+        "description": "clientservices.chat.models.ChatServiceModels",
         "peekOfCode": "class ChatServiceDataResponseModel(BaseModel):  \n    id: str\n    choices: List[ChatServiceChoiceModel] = []\n    created: int\n    model: str = \"llama-3.3-70b\"\n    totalTime: float = 0.0\n    usage: ChatServiceUsageModel\nclass ChatServiceResponseModel(BaseModel):\n    status: ChatServiceResponseStatusEnum = ChatServiceResponseStatusEnum.SUCCESS\n    LLMData: ChatServiceDataResponseModel | None = None",
-        "detail": "clientservices.cerebras.models.LLMModels",
+        "detail": "clientservices.chat.models.ChatServiceModels",
         "documentation": {}
     },
     {
         "label": "ChatServiceResponseModel",
         "kind": 6,
-        "importPath": "clientservices.cerebras.models.LLMModels",
-        "description": "clientservices.cerebras.models.LLMModels",
+        "importPath": "clientservices.chat.models.ChatServiceModels",
+        "description": "clientservices.chat.models.ChatServiceModels",
         "peekOfCode": "class ChatServiceResponseModel(BaseModel):\n    status: ChatServiceResponseStatusEnum = ChatServiceResponseStatusEnum.SUCCESS\n    LLMData: ChatServiceDataResponseModel | None = None",
-        "detail": "clientservices.cerebras.models.LLMModels",
+        "detail": "clientservices.chat.models.ChatServiceModels",
         "documentation": {}
     },
     {
         "label": "ChatService",
         "kind": 6,
-        "importPath": "clientservices.cerebras.services.ChatService",
-        "description": "clientservices.cerebras.services.ChatService",
+        "importPath": "clientservices.chat.services.ChatServices",
+        "description": "clientservices.chat.services.ChatServices",
         "peekOfCode": "class ChatService(ChatServiceImpl):\n    def HandleApiStatusError(self, statusCode: int) -> ChatServiceResponseModel:\n        errorCodes = {\n            400: ChatServiceResponseStatusEnum.BAD_REQUEST,\n            401: ChatServiceResponseStatusEnum.UNAUTHROZIED,\n            403: ChatServiceResponseStatusEnum.PERMISSION_DENIED,\n            404: ChatServiceResponseStatusEnum.NOT_FOUND,\n        }\n        message = errorCodes.get(statusCode, ChatServiceResponseStatusEnum.SERVER_ERROR)\n        return ChatServiceResponseModel(status=message)",
-        "detail": "clientservices.cerebras.services.ChatService",
+        "detail": "clientservices.chat.services.ChatServices",
         "documentation": {}
     },
     {
         "label": "client",
         "kind": 5,
-        "importPath": "clientservices.cerebras.services.ChatService",
-        "description": "clientservices.cerebras.services.ChatService",
+        "importPath": "clientservices.chat.services.ChatServices",
+        "description": "clientservices.chat.services.ChatServices",
         "peekOfCode": "client = AsyncCerebras(\n    api_key=GetCerebrasApiKey(),\n    http_client=DefaultAioHttpClient(),\n)\nclass ChatService(ChatServiceImpl):\n    def HandleApiStatusError(self, statusCode: int) -> ChatServiceResponseModel:\n        errorCodes = {\n            400: ChatServiceResponseStatusEnum.BAD_REQUEST,\n            401: ChatServiceResponseStatusEnum.UNAUTHROZIED,\n            403: ChatServiceResponseStatusEnum.PERMISSION_DENIED,",
-        "detail": "clientservices.cerebras.services.ChatService",
+        "detail": "clientservices.chat.services.ChatServices",
         "documentation": {}
     },
     {
         "label": "GetCerebrasApiKey",
         "kind": 2,
-        "importPath": "clientservices.cerebras.workers.GetApiKey",
-        "description": "clientservices.cerebras.workers.GetApiKey",
+        "importPath": "clientservices.chat.workers.GetApiKey",
+        "description": "clientservices.chat.workers.GetApiKey",
         "peekOfCode": "def GetCerebrasApiKey() ->str:\n    return CEREBRAS_API_KEY",
-        "detail": "clientservices.cerebras.workers.GetApiKey",
+        "detail": "clientservices.chat.workers.GetApiKey",
         "documentation": {}
     },
     {
         "label": "CEREBRAS_API_KEY",
         "kind": 5,
-        "importPath": "clientservices.cerebras.workers.GetApiKey",
-        "description": "clientservices.cerebras.workers.GetApiKey",
+        "importPath": "clientservices.chat.workers.GetApiKey",
+        "description": "clientservices.chat.workers.GetApiKey",
         "peekOfCode": "CEREBRAS_API_KEY = cast(Any, os.getenv(\"CEREBRAS_API_KEY\"))\ndef GetCerebrasApiKey() ->str:\n    return CEREBRAS_API_KEY",
-        "detail": "clientservices.cerebras.workers.GetApiKey",
+        "detail": "clientservices.chat.workers.GetApiKey",
         "documentation": {}
     },
     {
         "label": "MistralChatMessageRoleEnum",
         "kind": 6,
-        "importPath": "clientservices.mistral.enums.ChatEnums",
-        "description": "clientservices.mistral.enums.ChatEnums",
+        "importPath": "clientservices.embedding.enums.ChatEnums",
+        "description": "clientservices.embedding.enums.ChatEnums",
         "peekOfCode": "class MistralChatMessageRoleEnum(Enum):\n    USER = \"user\"\n    SYSTEM = \"system\"\n    ASSISTENT = \"assistant\"\nclass MistralChatResponseStatusEnum(Enum):\n    ERROR  = (500,\"ERROR\")\n    VALIDATION_ERROR = (422, \"VALIDATION_ERROR\")\n    SERVER_ERROR = (500, \"SERVER_ERROR\")\n    SUCCESS = (200, \"SUCCESS\")",
-        "detail": "clientservices.mistral.enums.ChatEnums",
+        "detail": "clientservices.embedding.enums.ChatEnums",
         "documentation": {}
     },
     {
         "label": "MistralChatResponseStatusEnum",
         "kind": 6,
-        "importPath": "clientservices.mistral.enums.ChatEnums",
-        "description": "clientservices.mistral.enums.ChatEnums",
+        "importPath": "clientservices.embedding.enums.ChatEnums",
+        "description": "clientservices.embedding.enums.ChatEnums",
         "peekOfCode": "class MistralChatResponseStatusEnum(Enum):\n    ERROR  = (500,\"ERROR\")\n    VALIDATION_ERROR = (422, \"VALIDATION_ERROR\")\n    SERVER_ERROR = (500, \"SERVER_ERROR\")\n    SUCCESS = (200, \"SUCCESS\")",
-        "detail": "clientservices.mistral.enums.ChatEnums",
+        "detail": "clientservices.embedding.enums.ChatEnums",
         "documentation": {}
     },
     {
         "label": "EmbeddingResponseEnum",
         "kind": 6,
-        "importPath": "clientservices.mistral.enums.EmbeddingEnums",
-        "description": "clientservices.mistral.enums.EmbeddingEnums",
+        "importPath": "clientservices.embedding.enums.EmbeddingEnums",
+        "description": "clientservices.embedding.enums.EmbeddingEnums",
         "peekOfCode": "class EmbeddingResponseEnum(Enum):\n    VALIDATION_ERROR = (422, \"VALIDATION_ERROR\")\n    SERVER_ERROR = (500, \"SERVER_ERROR\")\n    SUCCESS = (200, \"SUCCESS\")",
-        "detail": "clientservices.mistral.enums.EmbeddingEnums",
+        "detail": "clientservices.embedding.enums.EmbeddingEnums",
         "documentation": {}
     },
     {
         "label": "EmbeddingServiceImpl",
         "kind": 6,
-        "importPath": "clientservices.mistral.implementations.EmbeddingServiceimplementation",
-        "description": "clientservices.mistral.implementations.EmbeddingServiceimplementation",
-        "peekOfCode": "class EmbeddingServiceImpl(ABC):\n    @abstractmethod\n    async def ConvertTextToEmbedding(\n        self, text: list[str]\n    ) ->  EmbeddingResponseModel:\n        pass",
-        "detail": "clientservices.mistral.implementations.EmbeddingServiceimplementation",
+        "importPath": "clientservices.embedding.implementations.EmbeddingServiceimplementation",
+        "description": "clientservices.embedding.implementations.EmbeddingServiceimplementation",
+        "peekOfCode": "class EmbeddingServiceImpl(ABC):\n    @abstractmethod\n    async def ConvertTextToEmbedding(self, text: list[str]) -> EmbeddingResponseModel:\n        pass\n    @abstractmethod\n    def FindSimilarity(self, vec1: list[float], vec2: list[float]) -> float:\n        pass",
+        "detail": "clientservices.embedding.implementations.EmbeddingServiceimplementation",
         "documentation": {}
     },
     {
         "label": "MistralChatImpl",
         "kind": 6,
-        "importPath": "clientservices.mistral.implementations.MistralChatImpl",
-        "description": "clientservices.mistral.implementations.MistralChatImpl",
+        "importPath": "clientservices.embedding.implementations.MistralChatImpl",
+        "description": "clientservices.embedding.implementations.MistralChatImpl",
         "peekOfCode": "class MistralChatImpl(ABC):\n    @abstractmethod\n    async def Chat(\n        self, modelParams: MistralChatRequestModel\n    ) -> MistralChatResponseModel:\n        pass",
-        "detail": "clientservices.mistral.implementations.MistralChatImpl",
+        "detail": "clientservices.embedding.implementations.MistralChatImpl",
+        "documentation": {}
+    },
+    {
+        "label": "RerankingImpl",
+        "kind": 6,
+        "importPath": "clientservices.embedding.implementations.RerankingImplementation",
+        "description": "clientservices.embedding.implementations.RerankingImplementation",
+        "peekOfCode": "class RerankingImpl(ABC):\n    @abstractmethod\n    async def FindRankingScore(\n        self, modelParams: RerankingRequestModel\n    ) -> RerankingResponseModel:\n        pass",
+        "detail": "clientservices.embedding.implementations.RerankingImplementation",
         "documentation": {}
     },
     {
         "label": "MistralChatRequestMessageModel",
         "kind": 6,
-        "importPath": "clientservices.mistral.models.ChatModels",
-        "description": "clientservices.mistral.models.ChatModels",
+        "importPath": "clientservices.embedding.models.ChatModels",
+        "description": "clientservices.embedding.models.ChatModels",
         "peekOfCode": "class MistralChatRequestMessageModel(BaseModel):\n    role: MistralChatMessageRoleEnum = MistralChatMessageRoleEnum.USER\n    content: str | list[str]\nclass MistralChatRequestModel(BaseModel):\n    model: str = \"mistral-small-2506\"\n    temperature: float = 0.7\n    maxTokens: int = 30000\n    stream: bool = False\n    messages: list[MistralChatRequestMessageModel]\n    responseFormat: Any | None = None",
-        "detail": "clientservices.mistral.models.ChatModels",
+        "detail": "clientservices.embedding.models.ChatModels",
         "documentation": {}
     },
     {
         "label": "MistralChatRequestModel",
         "kind": 6,
-        "importPath": "clientservices.mistral.models.ChatModels",
-        "description": "clientservices.mistral.models.ChatModels",
+        "importPath": "clientservices.embedding.models.ChatModels",
+        "description": "clientservices.embedding.models.ChatModels",
         "peekOfCode": "class MistralChatRequestModel(BaseModel):\n    model: str = \"mistral-small-2506\"\n    temperature: float = 0.7\n    maxTokens: int = 30000\n    stream: bool = False\n    messages: list[MistralChatRequestMessageModel]\n    responseFormat: Any | None = None\nclass MistralChatResponseUsageModel(BaseModel):\n    promptTokens: int\n    completionToken: int",
-        "detail": "clientservices.mistral.models.ChatModels",
+        "detail": "clientservices.embedding.models.ChatModels",
         "documentation": {}
     },
     {
         "label": "MistralChatResponseUsageModel",
         "kind": 6,
-        "importPath": "clientservices.mistral.models.ChatModels",
-        "description": "clientservices.mistral.models.ChatModels",
+        "importPath": "clientservices.embedding.models.ChatModels",
+        "description": "clientservices.embedding.models.ChatModels",
         "peekOfCode": "class MistralChatResponseUsageModel(BaseModel):\n    promptTokens: int\n    completionToken: int\n    totalTokens: int\nclass MistralChatResponseMessageModel(BaseModel):\n    content: str\n    role: str | None = None\nclass MistralChatResponseChoiceModel(BaseModel):\n    index: int\n    message: MistralChatResponseMessageModel",
-        "detail": "clientservices.mistral.models.ChatModels",
+        "detail": "clientservices.embedding.models.ChatModels",
         "documentation": {}
     },
     {
         "label": "MistralChatResponseMessageModel",
         "kind": 6,
-        "importPath": "clientservices.mistral.models.ChatModels",
-        "description": "clientservices.mistral.models.ChatModels",
+        "importPath": "clientservices.embedding.models.ChatModels",
+        "description": "clientservices.embedding.models.ChatModels",
         "peekOfCode": "class MistralChatResponseMessageModel(BaseModel):\n    content: str\n    role: str | None = None\nclass MistralChatResponseChoiceModel(BaseModel):\n    index: int\n    message: MistralChatResponseMessageModel\nclass MistralChatResponseModel(BaseModel):\n    id: str | None = None\n    model: str | None = None\n    usgae: MistralChatResponseUsageModel | None = None",
-        "detail": "clientservices.mistral.models.ChatModels",
+        "detail": "clientservices.embedding.models.ChatModels",
         "documentation": {}
     },
     {
         "label": "MistralChatResponseChoiceModel",
         "kind": 6,
-        "importPath": "clientservices.mistral.models.ChatModels",
-        "description": "clientservices.mistral.models.ChatModels",
+        "importPath": "clientservices.embedding.models.ChatModels",
+        "description": "clientservices.embedding.models.ChatModels",
         "peekOfCode": "class MistralChatResponseChoiceModel(BaseModel):\n    index: int\n    message: MistralChatResponseMessageModel\nclass MistralChatResponseModel(BaseModel):\n    id: str | None = None\n    model: str | None = None\n    usgae: MistralChatResponseUsageModel | None = None\n    created: int | None = None\n    choices: list[MistralChatResponseChoiceModel] | None = None\n    status:MistralChatResponseStatusEnum",
-        "detail": "clientservices.mistral.models.ChatModels",
+        "detail": "clientservices.embedding.models.ChatModels",
         "documentation": {}
     },
     {
         "label": "MistralChatResponseModel",
         "kind": 6,
-        "importPath": "clientservices.mistral.models.ChatModels",
-        "description": "clientservices.mistral.models.ChatModels",
+        "importPath": "clientservices.embedding.models.ChatModels",
+        "description": "clientservices.embedding.models.ChatModels",
         "peekOfCode": "class MistralChatResponseModel(BaseModel):\n    id: str | None = None\n    model: str | None = None\n    usgae: MistralChatResponseUsageModel | None = None\n    created: int | None = None\n    choices: list[MistralChatResponseChoiceModel] | None = None\n    status:MistralChatResponseStatusEnum",
-        "detail": "clientservices.mistral.models.ChatModels",
+        "detail": "clientservices.embedding.models.ChatModels",
         "documentation": {}
     },
     {
         "label": "EmbeddingUsageModel",
         "kind": 6,
-        "importPath": "clientservices.mistral.models.EmbeddingModels",
-        "description": "clientservices.mistral.models.EmbeddingModels",
+        "importPath": "clientservices.embedding.models.EmbeddingModels",
+        "description": "clientservices.embedding.models.EmbeddingModels",
         "peekOfCode": "class EmbeddingUsageModel(BaseModel):\n    promptTokens: int | None\n    completionTokens: int | None\n    totalTokens: int | None\nclass EmbeddingDataModel(BaseModel):\n    index: int | None\n    embedding: list[float] | None\nclass EmbeddingResponseModel(BaseModel):\n    status: EmbeddingResponseEnum = (\n        EmbeddingResponseEnum.VALIDATION_ERROR",
-        "detail": "clientservices.mistral.models.EmbeddingModels",
+        "detail": "clientservices.embedding.models.EmbeddingModels",
         "documentation": {}
     },
     {
         "label": "EmbeddingDataModel",
         "kind": 6,
-        "importPath": "clientservices.mistral.models.EmbeddingModels",
-        "description": "clientservices.mistral.models.EmbeddingModels",
+        "importPath": "clientservices.embedding.models.EmbeddingModels",
+        "description": "clientservices.embedding.models.EmbeddingModels",
         "peekOfCode": "class EmbeddingDataModel(BaseModel):\n    index: int | None\n    embedding: list[float] | None\nclass EmbeddingResponseModel(BaseModel):\n    status: EmbeddingResponseEnum = (\n        EmbeddingResponseEnum.VALIDATION_ERROR\n    )\n    id: str | None = None\n    model: str  | None = None\n    usage: EmbeddingUsageModel | None = None",
-        "detail": "clientservices.mistral.models.EmbeddingModels",
+        "detail": "clientservices.embedding.models.EmbeddingModels",
         "documentation": {}
     },
     {
         "label": "EmbeddingResponseModel",
         "kind": 6,
-        "importPath": "clientservices.mistral.models.EmbeddingModels",
-        "description": "clientservices.mistral.models.EmbeddingModels",
+        "importPath": "clientservices.embedding.models.EmbeddingModels",
+        "description": "clientservices.embedding.models.EmbeddingModels",
         "peekOfCode": "class EmbeddingResponseModel(BaseModel):\n    status: EmbeddingResponseEnum = (\n        EmbeddingResponseEnum.VALIDATION_ERROR\n    )\n    id: str | None = None\n    model: str  | None = None\n    usage: EmbeddingUsageModel | None = None\n    data: list[EmbeddingDataModel] | None = None",
-        "detail": "clientservices.mistral.models.EmbeddingModels",
+        "detail": "clientservices.embedding.models.EmbeddingModels",
+        "documentation": {}
+    },
+    {
+        "label": "RerankingRequestModel",
+        "kind": 6,
+        "importPath": "clientservices.embedding.models.RerankingModels",
+        "description": "clientservices.embedding.models.RerankingModels",
+        "peekOfCode": "class RerankingRequestModel(BaseModel):\n    model: str = \"jina-reranker-m0\"\n    query: str\n    docs: list[str]\n    topN: int = 5\n    returnDocuments: bool = False\nclass RerankingResponseChoiseModel(BaseModel):\n    index: int\n    score: float\nclass RerankingUsageModel(BaseModel):",
+        "detail": "clientservices.embedding.models.RerankingModels",
+        "documentation": {}
+    },
+    {
+        "label": "RerankingResponseChoiseModel",
+        "kind": 6,
+        "importPath": "clientservices.embedding.models.RerankingModels",
+        "description": "clientservices.embedding.models.RerankingModels",
+        "peekOfCode": "class RerankingResponseChoiseModel(BaseModel):\n    index: int\n    score: float\nclass RerankingUsageModel(BaseModel):\n    totalTokens: int\nclass RerankingResponseModel(BaseModel):\n    response: list[RerankingResponseChoiseModel] | None = None\n    status: ChatServiceResponseStatusEnum = ChatServiceResponseStatusEnum.SUCCESS\n    usage: RerankingUsageModel | None = None",
+        "detail": "clientservices.embedding.models.RerankingModels",
+        "documentation": {}
+    },
+    {
+        "label": "RerankingUsageModel",
+        "kind": 6,
+        "importPath": "clientservices.embedding.models.RerankingModels",
+        "description": "clientservices.embedding.models.RerankingModels",
+        "peekOfCode": "class RerankingUsageModel(BaseModel):\n    totalTokens: int\nclass RerankingResponseModel(BaseModel):\n    response: list[RerankingResponseChoiseModel] | None = None\n    status: ChatServiceResponseStatusEnum = ChatServiceResponseStatusEnum.SUCCESS\n    usage: RerankingUsageModel | None = None",
+        "detail": "clientservices.embedding.models.RerankingModels",
+        "documentation": {}
+    },
+    {
+        "label": "RerankingResponseModel",
+        "kind": 6,
+        "importPath": "clientservices.embedding.models.RerankingModels",
+        "description": "clientservices.embedding.models.RerankingModels",
+        "peekOfCode": "class RerankingResponseModel(BaseModel):\n    response: list[RerankingResponseChoiseModel] | None = None\n    status: ChatServiceResponseStatusEnum = ChatServiceResponseStatusEnum.SUCCESS\n    usage: RerankingUsageModel | None = None",
+        "detail": "clientservices.embedding.models.RerankingModels",
         "documentation": {}
     },
     {
         "label": "EmbeddingService",
         "kind": 6,
-        "importPath": "clientservices.mistral.services.EmbeddingService",
-        "description": "clientservices.mistral.services.EmbeddingService",
-        "peekOfCode": "class EmbeddingService:\n    async def ConvertTextToEmbedding(self, text: list[str]) -> EmbeddingResponseModel:\n        try:\n            res: EmbeddingResponse = await mistralClient.embeddings.create_async(\n                model=\"mistral-embed\",\n                inputs=text,\n            )\n            data = [\n                EmbeddingDataModel(\n                    embedding=obj.embedding,",
-        "detail": "clientservices.mistral.services.EmbeddingService",
+        "importPath": "clientservices.embedding.services.EmbeddingService",
+        "description": "clientservices.embedding.services.EmbeddingService",
+        "peekOfCode": "class EmbeddingService(EmbeddingServiceImpl):\n    async def ConvertTextToEmbedding(self, text: list[str]) -> EmbeddingResponseModel:\n        try:\n            res: EmbeddingResponse = await mistralClient.embeddings.create_async(\n                model=\"mistral-embed\",\n                inputs=text,\n            )\n            data = [\n                EmbeddingDataModel(\n                    embedding=obj.embedding,",
+        "detail": "clientservices.embedding.services.EmbeddingService",
         "documentation": {}
     },
     {
         "label": "mistralClient",
         "kind": 5,
-        "importPath": "clientservices.mistral.services.EmbeddingService",
-        "description": "clientservices.mistral.services.EmbeddingService",
-        "peekOfCode": "mistralClient = Mistral(api_key=GetMistralApiKey())\nclass EmbeddingService:\n    async def ConvertTextToEmbedding(self, text: list[str]) -> EmbeddingResponseModel:\n        try:\n            res: EmbeddingResponse = await mistralClient.embeddings.create_async(\n                model=\"mistral-embed\",\n                inputs=text,\n            )\n            data = [\n                EmbeddingDataModel(",
-        "detail": "clientservices.mistral.services.EmbeddingService",
+        "importPath": "clientservices.embedding.services.EmbeddingService",
+        "description": "clientservices.embedding.services.EmbeddingService",
+        "peekOfCode": "mistralClient = Mistral(api_key=GetMistralApiKey())\nclass EmbeddingService(EmbeddingServiceImpl):\n    async def ConvertTextToEmbedding(self, text: list[str]) -> EmbeddingResponseModel:\n        try:\n            res: EmbeddingResponse = await mistralClient.embeddings.create_async(\n                model=\"mistral-embed\",\n                inputs=text,\n            )\n            data = [\n                EmbeddingDataModel(",
+        "detail": "clientservices.embedding.services.EmbeddingService",
         "documentation": {}
     },
     {
         "label": "MistralChatService",
         "kind": 6,
-        "importPath": "clientservices.mistral.services.MistralChatService",
-        "description": "clientservices.mistral.services.MistralChatService",
+        "importPath": "clientservices.embedding.services.MistralChatService",
+        "description": "clientservices.embedding.services.MistralChatService",
         "peekOfCode": "class MistralChatService(MistralChatImpl):\n    async def Chat(\n        self, modelParams: MistralChatRequestModel\n    ) -> MistralChatResponseModel:\n        try:\n            messages: Any = []\n            for message in modelParams.messages:\n                messages.append(\n                    {\"role\": message.role.value, \"content\": message.content}\n                )",
-        "detail": "clientservices.mistral.services.MistralChatService",
+        "detail": "clientservices.embedding.services.MistralChatService",
         "documentation": {}
     },
     {
         "label": "mistral",
         "kind": 5,
-        "importPath": "clientservices.mistral.services.MistralChatService",
-        "description": "clientservices.mistral.services.MistralChatService",
+        "importPath": "clientservices.embedding.services.MistralChatService",
+        "description": "clientservices.embedding.services.MistralChatService",
         "peekOfCode": "mistral = Mistral(api_key=GetMistralApiKey())\nclass MistralChatService(MistralChatImpl):\n    async def Chat(\n        self, modelParams: MistralChatRequestModel\n    ) -> MistralChatResponseModel:\n        try:\n            messages: Any = []\n            for message in modelParams.messages:\n                messages.append(\n                    {\"role\": message.role.value, \"content\": message.content}",
-        "detail": "clientservices.mistral.services.MistralChatService",
+        "detail": "clientservices.embedding.services.MistralChatService",
+        "documentation": {}
+    },
+    {
+        "label": "RerankingService",
+        "kind": 6,
+        "importPath": "clientservices.embedding.services.RerankingService",
+        "description": "clientservices.embedding.services.RerankingService",
+        "peekOfCode": "class RerankingService(RerankingImpl):\n    async def FindRankingScore(\n        self, modelParams: RerankingRequestModel\n    ) -> RerankingResponseModel:\n        try:\n            data: Any = {\n                \"model\": modelParams.model,\n                \"query\": modelParams.query,\n                \"documents\": modelParams.docs,\n                \"top_n\": modelParams.topN,",
+        "detail": "clientservices.embedding.services.RerankingService",
+        "documentation": {}
+    },
+    {
+        "label": "jinaClient",
+        "kind": 5,
+        "importPath": "clientservices.embedding.services.RerankingService",
+        "description": "clientservices.embedding.services.RerankingService",
+        "peekOfCode": "jinaClient = requests.Session()\njinaClient.headers.update(\n    {\n        \"Authorization\": f\"Bearer {GetJinaApiKey()}\",\n        \"Content-Type\": \"application/json\",\n    }\n)\nclass RerankingService(RerankingImpl):\n    async def FindRankingScore(\n        self, modelParams: RerankingRequestModel",
+        "detail": "clientservices.embedding.services.RerankingService",
         "documentation": {}
     },
     {
         "label": "GetMistralApiKey",
         "kind": 2,
-        "importPath": "clientservices.mistral.workers.GetApiKey",
-        "description": "clientservices.mistral.workers.GetApiKey",
-        "peekOfCode": "def GetMistralApiKey() ->str:\n    return Mistral_API_KEY",
-        "detail": "clientservices.mistral.workers.GetApiKey",
+        "importPath": "clientservices.embedding.workers.GetApiKey",
+        "description": "clientservices.embedding.workers.GetApiKey",
+        "peekOfCode": "def GetMistralApiKey() -> str:\n    return MISTARL_API_KEY\ndef GetJinaApiKey() -> str:\n    return JINA_API_KEY",
+        "detail": "clientservices.embedding.workers.GetApiKey",
         "documentation": {}
     },
     {
-        "label": "Mistral_API_KEY",
+        "label": "GetJinaApiKey",
+        "kind": 2,
+        "importPath": "clientservices.embedding.workers.GetApiKey",
+        "description": "clientservices.embedding.workers.GetApiKey",
+        "peekOfCode": "def GetJinaApiKey() -> str:\n    return JINA_API_KEY",
+        "detail": "clientservices.embedding.workers.GetApiKey",
+        "documentation": {}
+    },
+    {
+        "label": "MISTARL_API_KEY",
         "kind": 5,
-        "importPath": "clientservices.mistral.workers.GetApiKey",
-        "description": "clientservices.mistral.workers.GetApiKey",
-        "peekOfCode": "Mistral_API_KEY = cast(Any, os.getenv(\"MISTRAL_API_KEY\"))\ndef GetMistralApiKey() ->str:\n    return Mistral_API_KEY",
-        "detail": "clientservices.mistral.workers.GetApiKey",
+        "importPath": "clientservices.embedding.workers.GetApiKey",
+        "description": "clientservices.embedding.workers.GetApiKey",
+        "peekOfCode": "MISTARL_API_KEY = cast(Any, os.getenv(\"MISTRAL_API_KEY\"))\nJINA_API_KEY = cast(Any, os.getenv(\"JINA_API_KEY\"))\ndef GetMistralApiKey() -> str:\n    return MISTARL_API_KEY\ndef GetJinaApiKey() -> str:\n    return JINA_API_KEY",
+        "detail": "clientservices.embedding.workers.GetApiKey",
+        "documentation": {}
+    },
+    {
+        "label": "JINA_API_KEY",
+        "kind": 5,
+        "importPath": "clientservices.embedding.workers.GetApiKey",
+        "description": "clientservices.embedding.workers.GetApiKey",
+        "peekOfCode": "JINA_API_KEY = cast(Any, os.getenv(\"JINA_API_KEY\"))\ndef GetMistralApiKey() -> str:\n    return MISTARL_API_KEY\ndef GetJinaApiKey() -> str:\n    return JINA_API_KEY",
+        "detail": "clientservices.embedding.workers.GetApiKey",
         "documentation": {}
     },
     {
@@ -1850,7 +2133,7 @@
         "kind": 6,
         "importPath": "graphrag.implementations.FileChunkGragImpl",
         "description": "graphrag.implementations.FileChunkGragImpl",
-        "peekOfCode": "class FileChunkGragImpl(ABC):\n    @abstractmethod\n    def ExatrctChunkFromText(\n        self, file: str, chunkSize: int, chunkOLSize: int | None = 0\n    ) -> list[str]:\n        pass\n    async def HandleKgExatrctProcess(self, file: str):\n        pass",
+        "peekOfCode": "class FileChunkGragImpl(ABC):\n    @abstractmethod\n    def ExatrctChunkFromText(\n        self, file: str, chunkSize: int, chunkOLSize: int | None = 0\n    ) -> list[str]:\n        pass\n    @abstractmethod\n    async def handleKgChunkRelationExtarctProcess(\n        self, file: str\n    ) -> HandleChunkRelationExtractResponseModel:",
         "detail": "graphrag.implementations.FileChunkGragImpl",
         "documentation": {}
     },
@@ -1859,7 +2142,16 @@
         "kind": 6,
         "importPath": "graphrag.models.FileChunkGragModels",
         "description": "graphrag.models.FileChunkGragModels",
-        "peekOfCode": "class LLMGragEntityResponseModel(BaseModel):\n    entities: list[list[str]]\n    relations: list[list[str]]\n    relationshipsEntities: list[list[list[str]]]\n    chunk: list[str]\nclass ChunkTextsModel(BaseModel):\n    id: UUID\n    text: str\n    vector:list[float] | None  = None\nclass ChunkRelationModel(BaseModel):",
+        "peekOfCode": "class LLMGragEntityResponseModel(BaseModel):\n    relations: list[list[str]]\n    relationshipsEntities: list[list[list[str]]]\n    chunk: list[str]\nclass ChunkNodeModel(BaseModel):\n    score: float\n    chunkId: UUID\nclass ChunkTextsModel(BaseModel):\n    id: UUID\n    text: str",
+        "detail": "graphrag.models.FileChunkGragModels",
+        "documentation": {}
+    },
+    {
+        "label": "ChunkNodeModel",
+        "kind": 6,
+        "importPath": "graphrag.models.FileChunkGragModels",
+        "description": "graphrag.models.FileChunkGragModels",
+        "peekOfCode": "class ChunkNodeModel(BaseModel):\n    score: float\n    chunkId: UUID\nclass ChunkTextsModel(BaseModel):\n    id: UUID\n    text: str\n    vector: list[float] | None = None\n    entities: list[str]\n    questions: list[str]\n    questionVectors: list[list[float]] | None = []",
         "detail": "graphrag.models.FileChunkGragModels",
         "documentation": {}
     },
@@ -1868,7 +2160,16 @@
         "kind": 6,
         "importPath": "graphrag.models.FileChunkGragModels",
         "description": "graphrag.models.FileChunkGragModels",
-        "peekOfCode": "class ChunkTextsModel(BaseModel):\n    id: UUID\n    text: str\n    vector:list[float] | None  = None\nclass ChunkRelationModel(BaseModel):\n    realtion: str\n    realtionEntites: list[str]\nclass ChunkRelationsModel(BaseModel):\n    chunkId: UUID\n    chunkRelations: list[ChunkRelationModel]",
+        "peekOfCode": "class ChunkTextsModel(BaseModel):\n    id: UUID\n    text: str\n    vector: list[float] | None = None\n    entities: list[str]\n    questions: list[str]\n    questionVectors: list[list[float]] | None = []\n    matchedNodes: list[ChunkNodeModel] | None = None\nclass RelationNodeModel(BaseModel):\n    realtionId: UUID",
+        "detail": "graphrag.models.FileChunkGragModels",
+        "documentation": {}
+    },
+    {
+        "label": "RelationNodeModel",
+        "kind": 6,
+        "importPath": "graphrag.models.FileChunkGragModels",
+        "description": "graphrag.models.FileChunkGragModels",
+        "peekOfCode": "class RelationNodeModel(BaseModel):\n    realtionId: UUID\n    score: float\nclass ChunkRelationModel(BaseModel):\n    id: UUID\n    realtion: str\n    realtionEntites: list[str]\n    relationVector: list[float] | None = None\n    matchedRelationNodes: list[RelationNodeModel] | None = None\nclass ChunkRelationsModel(BaseModel):",
         "detail": "graphrag.models.FileChunkGragModels",
         "documentation": {}
     },
@@ -1877,7 +2178,7 @@
         "kind": 6,
         "importPath": "graphrag.models.FileChunkGragModels",
         "description": "graphrag.models.FileChunkGragModels",
-        "peekOfCode": "class ChunkRelationModel(BaseModel):\n    realtion: str\n    realtionEntites: list[str]\nclass ChunkRelationsModel(BaseModel):\n    chunkId: UUID\n    chunkRelations: list[ChunkRelationModel]\nclass ChunkEntitiesModel(BaseModel):\n    chunkId: UUID\n    chunkEntities: list[str]\nclass ChunkTextVectors",
+        "peekOfCode": "class ChunkRelationModel(BaseModel):\n    id: UUID\n    realtion: str\n    realtionEntites: list[str]\n    relationVector: list[float] | None = None\n    matchedRelationNodes: list[RelationNodeModel] | None = None\nclass ChunkRelationsModel(BaseModel):\n    chunkId: UUID\n    chunkRelations: list[ChunkRelationModel]\nclass HandleChunkRelationExtractResponseModel(BaseModel):",
         "detail": "graphrag.models.FileChunkGragModels",
         "documentation": {}
     },
@@ -1886,25 +2187,25 @@
         "kind": 6,
         "importPath": "graphrag.models.FileChunkGragModels",
         "description": "graphrag.models.FileChunkGragModels",
-        "peekOfCode": "class ChunkRelationsModel(BaseModel):\n    chunkId: UUID\n    chunkRelations: list[ChunkRelationModel]\nclass ChunkEntitiesModel(BaseModel):\n    chunkId: UUID\n    chunkEntities: list[str]\nclass ChunkTextVectors",
+        "peekOfCode": "class ChunkRelationsModel(BaseModel):\n    chunkId: UUID\n    chunkRelations: list[ChunkRelationModel]\nclass HandleChunkRelationExtractResponseModel(BaseModel):\n    chunkTexts: list[ChunkTextsModel]\n    chunkRelations: list[ChunkRelationsModel]\nclass AllRelationsModel(BaseModel):\n    id: UUID\n    text: str\n    chunkId: UUID",
         "detail": "graphrag.models.FileChunkGragModels",
         "documentation": {}
     },
     {
-        "label": "ChunkEntitiesModel",
+        "label": "HandleChunkRelationExtractResponseModel",
         "kind": 6,
         "importPath": "graphrag.models.FileChunkGragModels",
         "description": "graphrag.models.FileChunkGragModels",
-        "peekOfCode": "class ChunkEntitiesModel(BaseModel):\n    chunkId: UUID\n    chunkEntities: list[str]\nclass ChunkTextVectors",
+        "peekOfCode": "class HandleChunkRelationExtractResponseModel(BaseModel):\n    chunkTexts: list[ChunkTextsModel]\n    chunkRelations: list[ChunkRelationsModel]\nclass AllRelationsModel(BaseModel):\n    id: UUID\n    text: str\n    chunkId: UUID\n    matchedRelationNodes: list[RelationNodeModel] | None = None",
         "detail": "graphrag.models.FileChunkGragModels",
         "documentation": {}
     },
     {
-        "label": "ChunkTextVector",
+        "label": "AllRelationsModel",
         "kind": 6,
         "importPath": "graphrag.models.FileChunkGragModels",
         "description": "graphrag.models.FileChunkGragModels",
-        "peekOfCode": "class ChunkTextVectors",
+        "peekOfCode": "class AllRelationsModel(BaseModel):\n    id: UUID\n    text: str\n    chunkId: UUID\n    matchedRelationNodes: list[RelationNodeModel] | None = None",
         "detail": "graphrag.models.FileChunkGragModels",
         "documentation": {}
     },
@@ -1918,11 +2219,11 @@
         "documentation": {}
     },
     {
-        "label": "ChatService",
+        "label": "chatService",
         "kind": 5,
         "importPath": "graphrag.services.FieChunkGrag",
         "description": "graphrag.services.FieChunkGrag",
-        "peekOfCode": "ChatService = ChatService()\nembeddingService = EmbeddingService()\nclass FileChunkGragService(FileChunkGragImpl):\n    def ExatrctChunkFromText(\n        self, file: str, chunkSize: int, chunkOLSize: int | None = 0\n    ) -> list[str]:\n        _PAGE_RE = re.compile(r\"\\bpage\\s+\\d+\\s+of\\s+\\d+\\b\", re.IGNORECASE)\n        _IMAGE_RE = re.compile(r\"\\s*(<<IMAGE-\\d+>>)\\s*\", re.IGNORECASE)\n        _BULLET_LINE_RE = re.compile(r\"^[\\s•\\-\\*\\u2022\\uf0b7FÞ]+(?=\\S)\", re.MULTILINE)\n        _SOFT_HYPHEN_RE = re.compile(r\"\\u00AD\")",
+        "peekOfCode": "chatService = ChatService()\nembeddingService = EmbeddingService()\nrerankingService = RerankingService()\nclass FileChunkGragService(FileChunkGragImpl):\n    def ExatrctChunkFromText(\n        self, file: str, chunkSize: int, chunkOLSize: int | None = 0\n    ) -> list[str]:\n        _PAGE_RE = re.compile(r\"\\bpage\\s+\\d+\\s+of\\s+\\d+\\b\", re.IGNORECASE)\n        _IMAGE_RE = re.compile(r\"\\s*(<<IMAGE-\\d+>>)\\s*\", re.IGNORECASE)\n        _BULLET_LINE_RE = re.compile(r\"^[\\s•\\-\\*\\u2022\\uf0b7FÞ]+(?=\\S)\", re.MULTILINE)",
         "detail": "graphrag.services.FieChunkGrag",
         "documentation": {}
     },
@@ -1931,17 +2232,26 @@
         "kind": 5,
         "importPath": "graphrag.services.FieChunkGrag",
         "description": "graphrag.services.FieChunkGrag",
-        "peekOfCode": "embeddingService = EmbeddingService()\nclass FileChunkGragService(FileChunkGragImpl):\n    def ExatrctChunkFromText(\n        self, file: str, chunkSize: int, chunkOLSize: int | None = 0\n    ) -> list[str]:\n        _PAGE_RE = re.compile(r\"\\bpage\\s+\\d+\\s+of\\s+\\d+\\b\", re.IGNORECASE)\n        _IMAGE_RE = re.compile(r\"\\s*(<<IMAGE-\\d+>>)\\s*\", re.IGNORECASE)\n        _BULLET_LINE_RE = re.compile(r\"^[\\s•\\-\\*\\u2022\\uf0b7FÞ]+(?=\\S)\", re.MULTILINE)\n        _SOFT_HYPHEN_RE = re.compile(r\"\\u00AD\")\n        _HYPHEN_BREAK_RE = re.compile(r\"(\\w)-\\n(\\w)\")",
+        "peekOfCode": "embeddingService = EmbeddingService()\nrerankingService = RerankingService()\nclass FileChunkGragService(FileChunkGragImpl):\n    def ExatrctChunkFromText(\n        self, file: str, chunkSize: int, chunkOLSize: int | None = 0\n    ) -> list[str]:\n        _PAGE_RE = re.compile(r\"\\bpage\\s+\\d+\\s+of\\s+\\d+\\b\", re.IGNORECASE)\n        _IMAGE_RE = re.compile(r\"\\s*(<<IMAGE-\\d+>>)\\s*\", re.IGNORECASE)\n        _BULLET_LINE_RE = re.compile(r\"^[\\s•\\-\\*\\u2022\\uf0b7FÞ]+(?=\\S)\", re.MULTILINE)\n        _SOFT_HYPHEN_RE = re.compile(r\"\\u00AD\")",
+        "detail": "graphrag.services.FieChunkGrag",
+        "documentation": {}
+    },
+    {
+        "label": "rerankingService",
+        "kind": 5,
+        "importPath": "graphrag.services.FieChunkGrag",
+        "description": "graphrag.services.FieChunkGrag",
+        "peekOfCode": "rerankingService = RerankingService()\nclass FileChunkGragService(FileChunkGragImpl):\n    def ExatrctChunkFromText(\n        self, file: str, chunkSize: int, chunkOLSize: int | None = 0\n    ) -> list[str]:\n        _PAGE_RE = re.compile(r\"\\bpage\\s+\\d+\\s+of\\s+\\d+\\b\", re.IGNORECASE)\n        _IMAGE_RE = re.compile(r\"\\s*(<<IMAGE-\\d+>>)\\s*\", re.IGNORECASE)\n        _BULLET_LINE_RE = re.compile(r\"^[\\s•\\-\\*\\u2022\\uf0b7FÞ]+(?=\\S)\", re.MULTILINE)\n        _SOFT_HYPHEN_RE = re.compile(r\"\\u00AD\")\n        _HYPHEN_BREAK_RE = re.compile(r\"(\\w)-\\n(\\w)\")",
         "detail": "graphrag.services.FieChunkGrag",
         "documentation": {}
     },
     {
         "label": "ExtractEntityGragSystemPrompt",
         "kind": 5,
-        "importPath": "graphrag.utils.GragSystemPropts",
-        "description": "graphrag.utils.GragSystemPropts",
+        "importPath": "graphrag.utils.FileGragSystemPropts",
+        "description": "graphrag.utils.FileGragSystemPropts",
         "peekOfCode": "ExtractEntityGragSystemPrompt = r\"\"\"\nTASK\nReturn ONLY valid JSON per the schema for ONE input chunk.\nINPUT\n{ \"chunk\": \"...\" }\nOUTPUT (conceptual)\n{\n  \"response\": {\n    \"entities\": [\"...\"],\n    \"relations\": [\"...\"],   // short declarative KG-style relations",
-        "detail": "graphrag.utils.GragSystemPropts",
+        "detail": "graphrag.utils.FileGragSystemPropts",
         "documentation": {}
     },
     {
@@ -2273,7 +2583,7 @@
         "kind": 5,
         "importPath": "k",
         "description": "k",
-        "peekOfCode": "a = FileChunkGragService()\nasync def main():\n    await a.HandleKgExatrctProcess(\"opd_manual.pdf\")\nif __name__ == \"__main__\":\n    import asyncio\n    asyncio.run(main())",
+        "peekOfCode": "a = FileChunkGragService()\nasync def main():\n    await a.HandleGraphBuildingProcess(\"opd_manual.pdf\")\nif __name__ == \"__main__\":\n    import asyncio\n    asyncio.run(main())",
         "detail": "k",
         "documentation": {}
     },
@@ -2282,7 +2592,7 @@
         "kind": 5,
         "importPath": "main",
         "description": "main",
-        "peekOfCode": "DATABASE_CONNECTION_STRING = os.getenv(\"DATABASE_CONNECTION_STRING\", \"\")\npsqlDb = PsqlDb(DATABASE_CONNECTION_STRING)     \n@asynccontextmanager\nasync def lifespan(app: FastAPI):\n    # await psqlDb.connect()\n    yield\n    # await psqlDb.close()\nserver = FastAPI(lifespan=lifespan)\nserver.add_middleware(\n    CORSMiddleware,",
+        "peekOfCode": "DATABASE_CONNECTION_STRING = os.getenv(\"DATABASE_CONNECTION_STRING\", \"\")\npsqlDb = PsqlDb(DATABASE_CONNECTION_STRING)\n@asynccontextmanager\nasync def lifespan(app: FastAPI):\n    # await psqlDb.connect()\n    yield\n    # await psqlDb.close()\nserver = FastAPI(lifespan=lifespan)\nserver.add_middleware(\n    CORSMiddleware,",
         "detail": "main",
         "documentation": {}
     },
@@ -2291,7 +2601,7 @@
         "kind": 5,
         "importPath": "main",
         "description": "main",
-        "peekOfCode": "psqlDb = PsqlDb(DATABASE_CONNECTION_STRING)     \n@asynccontextmanager\nasync def lifespan(app: FastAPI):\n    # await psqlDb.connect()\n    yield\n    # await psqlDb.close()\nserver = FastAPI(lifespan=lifespan)\nserver.add_middleware(\n    CORSMiddleware,\n    allow_origins=[\"*\"],",
+        "peekOfCode": "psqlDb = PsqlDb(DATABASE_CONNECTION_STRING)\n@asynccontextmanager\nasync def lifespan(app: FastAPI):\n    # await psqlDb.connect()\n    yield\n    # await psqlDb.close()\nserver = FastAPI(lifespan=lifespan)\nserver.add_middleware(\n    CORSMiddleware,\n    allow_origins=[\"*\"],",
         "detail": "main",
         "documentation": {}
     },

--- a/a.json
+++ b/a.json
@@ -1,2 +1,21 @@
-The Outpatient Department (OPD) module on the HMIS website is designed for management of outpatient services in healthcare facilities. Here are some key features and functions of the OPD module:  Patient Registration : Allows for the quick and efficient registration of patients, capturing essential demographic and medical history information.  Consultation Records : Enables doctors to document and track patient consultations, diagnosis, and prescribed treatments or medications.  Laboratory and Diagnostic Integration : Order laboratory and diagnostic services to Laboratories and retrieve
-[[RerankingResponseChoiseModel(index=2, score=0.9406621404432519), RerankingResponseChoiseModel(index=3, score=0.8960290325536018), RerankingResponseChoiseModel(index=1, score=0.8881584157331672)], [RerankingResponseChoiseModel(index=4, score=0.8907504577496148), RerankingResponseChoiseModel(index=1, score=0.8894381535472538), RerankingResponseChoiseModel(index=2, score=0.885458723352741)], [RerankingResponseChoiseModel(index=3, score=0.8731272714133471), RerankingResponseChoiseModel(index=1, score=0.8699424496788684), RerankingResponseChoiseModel(index=2, score=0.8601715154502759)]]
+[{'id': UUID('97678b5c-716b-46c8-9285-17352fa24ecf'), 'text': 'The Outpatient Department (OPD) module on the HMIS website is designed for management of outpatient services in healthcare facilities. Here are some key features and functions of the OPD module: \uf046 Patient Registration : Allows for the quick and efficient registration of patients, capturing essential demographic and medical history information. \uf046 Consultation Records : Enables doctors to document and track patient consultations, diagnosis, and prescribed treatments or medications. \uf046 Laboratory and Diagnostic Integration : Order laboratory and diagnostic services to Laboratories and retrieve'}, 
+
+
+
+
+
+{'id': UUID('f9d66bb5-9265-40a0-bf52-b15ca4b63164'), 'text': 'test results, helping in the timely diagnosis and treatment of patients. \uf046 Inventory Integration : Order drugs and items to pharmacy directly from doctor desk current stock details can be viewed by doctor helping to raising indent for drugs form OPD desk. \uf046 Reporting and Analytics : Provides tools for generating various reports and analytics, helping Doctors monitor service delivery and identify areas for improvement. \uf046 Ordering to other services: Ordering other services in Hospital directly from OPD doctor desk like, Surgeries, Procedures, Services, referral to other departments / Hospitals,'}, 
+
+
+
+{'id': UUID('f2f8463e-26e5-4a39-acdf-54415ae0f059'), 'text': 'etc. These fea
+tures help improve the efficiency and quality of outpatient care, reduce wait times, and enhance patient satisfaction. Benefits of the OPD Doctor Desk \uf046 Improved Efficiency: Streamlines various administrative and clinical tasks, allowing doctors to focus more on patient care. \uf046 Enhanced Patient Care: Provides comprehensive patient information at the point of care, supporting better clinical decisions. \uf046 Reduced Errors: Minimizes errors associated with manual data entry and paper records. \uf046 Patient Satisfaction: Enhances patient satisfaction through timely services, reduced wait'},
+
+
+
+{'id': UUID('55ded55e-5565-4676-bc32-004074691724'), 'text': 'times, and better communication. OPD Desk lite page The OPD Doctor Desk is a vital component of the HMIS, aiming to improve the overall quality of outpatient services and ensure a seamless experience for both healthcare providers and patients. <<IMAGE-1>> 1.1 View Total Registered and Attended Patients: View real-time data on the total number of patients registered in the current Department / Unit. Additionally, it provides information on how many of those patients have been attended to. 1.2. Responsive View Button: Clicking on this button opens a new tab in the browser, allowing the user to'}, 
+
+
+
+
+{'id': UUID('bf5f21c4-72ea-4f8b-aca3-26c3046cb93b'), 'text': 'view a separate list for same or another department simultaneously. This facilitates parallel management and provides a full-page view of the OPD desk for better visibility on PC and mobile browsers. 1.3. Dept/Unit Dropdown: The dropdown menu lists the Departments/Units based on the access assigned by the administrator. or adding or removing Departments/Units, users should contact the Hospital Administration to update access permissions. This dropdown allows doctors to switch between departments and rooms according to their assigned access. The list is alphabetically ordered, with the first'}]

--- a/clientservices/__init__.py
+++ b/clientservices/__init__.py
@@ -35,6 +35,7 @@ from .embedding import (
     RerankingResponseChoiseModel,
     RerankingResponseModel,
     RerankingUsageModel,
+    GetJinaApiKey
 )
 
 
@@ -73,4 +74,5 @@ __all__ = [
     "RerankingResponseChoiseModel",
     "RerankingResponseModel",
     "RerankingUsageModel",
+    "GetJinaApiKey"
 ]

--- a/clientservices/embedding/__init__.py
+++ b/clientservices/embedding/__init__.py
@@ -1,4 +1,4 @@
-from .workers import GetMistralApiKey
+from .workers import GetMistralApiKey, GetJinaApiKey
 from .services import EmbeddingService, MistralChatService, RerankingService
 from .enums import (
     EmbeddingResponseEnum,
@@ -43,5 +43,6 @@ __all__ = [
     "RerankingRequestModel",
     "RerankingResponseChoiseModel",
     "RerankingResponseModel",
-    "RerankingUsageModel"
+    "RerankingUsageModel",
+    "GetJinaApiKey",
 ]

--- a/clientservices/embedding/models/RerankingModels.py
+++ b/clientservices/embedding/models/RerankingModels.py
@@ -3,10 +3,11 @@ from clientservices.chat.enums import ChatServiceResponseStatusEnum
 
 
 class RerankingRequestModel(BaseModel):
-    model: str = "Salesforce/Llama-Rank-v1"
+    model: str = "jina-reranker-m0"
     query: str
     docs: list[str]
     topN: int = 5
+    returnDocuments: bool = False
 
 
 class RerankingResponseChoiseModel(BaseModel):

--- a/clientservices/embedding/services/RerankingService.py
+++ b/clientservices/embedding/services/RerankingService.py
@@ -1,19 +1,22 @@
 from typing import Any
-from together import AsyncTogether
-import together.error as APIError
 from clientservices.embedding.models import (
     RerankingRequestModel,
     RerankingResponseModel,
     RerankingResponseChoiseModel,
     RerankingUsageModel,
 )
+import requests
 
 from clientservices.chat.enums import ChatServiceResponseStatusEnum
-
 from clientservices.embedding.implementations import RerankingImpl
+from clientservices.embedding.workers import GetJinaApiKey
 
-rerankerClient = AsyncTogether(
-    api_key="e01e224345314f2b1e73f6cf1503313223886531b13ff1829547f1bfe43c7690"
+jinaClient = requests.Session()
+jinaClient.headers.update(
+    {
+        "Authorization": f"Bearer {GetJinaApiKey()}",
+        "Content-Type": "application/json",
+    }
 )
 
 
@@ -22,23 +25,27 @@ class RerankingService(RerankingImpl):
     async def FindRankingScore(
         self, modelParams: RerankingRequestModel
     ) -> RerankingResponseModel:
-
         try:
-            response: Any = await rerankerClient.rerank.create(
-                model=modelParams.model,
-                query=modelParams.query,
-                documents=modelParams.docs,
-                top_n=modelParams.topN,
-            )
-            if response.id is not None and response.results is not None:
+
+            data: Any = {
+                "model": modelParams.model,
+                "query": modelParams.query,
+                "documents": modelParams.docs,
+                "top_n": modelParams.topN,
+                "return_documents": modelParams.returnDocuments,
+            }
+            res = jinaClient.post("https://api.jina.ai/v1/rerank", json=data)
+            response = res.json()
+            
+            if response.get("model") is not None and response.get("results") is not None:
                 return RerankingResponseModel(
                     response=[
                         RerankingResponseChoiseModel(
-                            index=choice.index, score=choice.relevance_score
+                            index=choice.get("index"), score=choice.get("relevance_score")
                         )
-                        for choice in response.results
+                        for choice in response.get("results")
                     ],
-                    usage=RerankingUsageModel(totalTokens=response.usage.total_tokens),
+                    usage=RerankingUsageModel(totalTokens=response.get("usage").get("total_tokens")),
                     status=ChatServiceResponseStatusEnum.SUCCESS,
                 )
 
@@ -46,21 +53,7 @@ class RerankingService(RerankingImpl):
                 status=ChatServiceResponseStatusEnum.ERROR,
             )
 
-        except APIError.InvalidRequestError:
-            return RerankingResponseModel(
-                status=ChatServiceResponseStatusEnum.BAD_REQUEST
-            )
-        except APIError.AuthenticationError:
-            return RerankingResponseModel(
-                status=ChatServiceResponseStatusEnum.UNAUTHROZIED
-            )
-        except APIError.RequestException:
-            return RerankingResponseModel(
-                status=ChatServiceResponseStatusEnum.BAD_REQUEST
-            )
-
-        except Exception as e:
-            print(e)
+        except Exception:
             return RerankingResponseModel(
                 status=ChatServiceResponseStatusEnum.SERVER_ERROR
             )

--- a/clientservices/embedding/workers/GetApiKey.py
+++ b/clientservices/embedding/workers/GetApiKey.py
@@ -1,11 +1,17 @@
 import os
 from typing import Any, cast
 from dotenv import load_dotenv
+
 load_dotenv()
 
 
-Mistral_API_KEY = cast(Any, os.getenv("MISTRAL_API_KEY"))
+MISTARL_API_KEY = cast(Any, os.getenv("MISTRAL_API_KEY"))
+JINA_API_KEY = cast(Any, os.getenv("JINA_API_KEY"))
 
 
-def GetMistralApiKey() ->str:
-    return Mistral_API_KEY
+def GetMistralApiKey() -> str:
+    return MISTARL_API_KEY
+
+
+def GetJinaApiKey() -> str:
+    return JINA_API_KEY

--- a/clientservices/embedding/workers/__init__.py
+++ b/clientservices/embedding/workers/__init__.py
@@ -1,6 +1,4 @@
-from .GetApiKey import GetMistralApiKey
+from .GetApiKey import GetMistralApiKey, GetJinaApiKey
 
 
-__all__ = [
-    "GetMistralApiKey"
-]
+__all__ = ["GetMistralApiKey", "GetJinaApiKey"]

--- a/graphrag/implementations/FileChunkGragImpl.py
+++ b/graphrag/implementations/FileChunkGragImpl.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from graphrag.models import HandleKgExatrctProcessResponseModel
+from graphrag.models import HandleChunkRelationExtractResponseModel
 
 
 class FileChunkGragImpl(ABC):
@@ -11,9 +11,9 @@ class FileChunkGragImpl(ABC):
         pass
 
     @abstractmethod
-    async def HandleRelationExtarctProcess(
+    async def handleKgChunkRelationExtarctProcess(
         self, file: str
-    ) -> HandleKgExatrctProcessResponseModel:
+    ) -> HandleChunkRelationExtractResponseModel:
         pass
 
     @abstractmethod

--- a/graphrag/models/FileChunkGragModels.py
+++ b/graphrag/models/FileChunkGragModels.py
@@ -8,12 +8,24 @@ class LLMGragEntityResponseModel(BaseModel):
     chunk: list[str]
 
 
+class ChunkNodeModel(BaseModel):
+    score: float
+    chunkId: UUID
+
+
 class ChunkTextsModel(BaseModel):
     id: UUID
     text: str
     vector: list[float] | None = None
     entities: list[str]
+    questions: list[str]
+    questionVectors: list[list[float]] | None = []
+    matchedNodes: list[ChunkNodeModel] | None = None
 
+
+class RelationNodeModel(BaseModel):
+    realtionId: UUID
+    score: float
 
 
 class ChunkRelationModel(BaseModel):
@@ -21,6 +33,7 @@ class ChunkRelationModel(BaseModel):
     realtion: str
     realtionEntites: list[str]
     relationVector: list[float] | None = None
+    matchedRelationNodes: list[RelationNodeModel] | None = None
 
 
 class ChunkRelationsModel(BaseModel):
@@ -28,8 +41,15 @@ class ChunkRelationsModel(BaseModel):
     chunkRelations: list[ChunkRelationModel]
 
 
-    
-
-class HandleKgExatrctProcessResponseModel(BaseModel):
+class HandleChunkRelationExtractResponseModel(BaseModel):
     chunkTexts: list[ChunkTextsModel]
     chunkRelations: list[ChunkRelationsModel]
+
+
+
+
+class AllRelationsModel(BaseModel):
+    id: UUID
+    text: str
+    chunkId: UUID
+    matchedRelationNodes: list[RelationNodeModel] | None = None

--- a/graphrag/models/__init__.py
+++ b/graphrag/models/__init__.py
@@ -3,7 +3,10 @@ from .FileChunkGragModels import (
     ChunkRelationsModel,
     ChunkTextsModel,
     ChunkRelationModel,
-    HandleKgExatrctProcessResponseModel
+    HandleChunkRelationExtractResponseModel,
+    ChunkNodeModel,
+    RelationNodeModel,
+    AllRelationsModel,
 )
 
 
@@ -12,5 +15,8 @@ __all__ = [
     "ChunkTextsModel",
     "ChunkRelationsModel",
     "ChunkRelationModel",
-    "HandleKgExatrctProcessResponseModel"
+    "HandleChunkRelationExtractResponseModel",
+    "ChunkNodeModel",
+    "AllRelationsModel",
+    "RelationNodeModel",
 ]

--- a/graphrag/utils/FileGragSystemPropts.py
+++ b/graphrag/utils/FileGragSystemPropts.py
@@ -11,6 +11,7 @@ OUTPUT (conceptual)
   "response": {
     "entities": ["..."],
     "relations": ["..."],   // short declarative KG-style relations
+    "questions": ["..."],   // possible question which has anser in this chunk 
     "relationshipsEntities": [["A","B"], ...],
     "chunk": "..."
   }
@@ -22,6 +23,7 @@ RULES
 - Do NOT invent entities/links/images.
 - Entities: concise (≤15 chars), lowercase unless proper noun; deduplicate.
 - Relations: Form all relation between entites must greter then 12 dont miss any realtion.
+- Questions: Form all questions from this chunk and must have answer in this chunk minimum 3-7 questions per chunk 
 - Relations should follow a KG-friendly style:
    • subject → predicate → object
 Dont remove any images (<<IMAGE-N>>) or links from the chunk.

--- a/k.py
+++ b/k.py
@@ -1,9 +1,11 @@
 from graphrag import FileChunkGragService
+import time
 
 a = FileChunkGragService()
 
 
 async def main():
+
     await a.HandleGraphBuildingProcess("opd_manual.pdf")
 
 

--- a/main.py
+++ b/main.py
@@ -6,11 +6,12 @@ from contextlib import asynccontextmanager
 from server import PsqlDb
 from server import QaRag
 from server import CustomMidlleware
+from clientservices import RerankingService
 
 load_dotenv()
 
 DATABASE_CONNECTION_STRING = os.getenv("DATABASE_CONNECTION_STRING", "")
-psqlDb = PsqlDb(DATABASE_CONNECTION_STRING)     
+psqlDb = PsqlDb(DATABASE_CONNECTION_STRING)
 
 
 @asynccontextmanager
@@ -31,6 +32,7 @@ server.add_middleware(
 )
 server.add_middleware(CustomMidlleware)
 server.include_router(QaRag, prefix="/api/v1/qa")
+RerankingService()
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
- Updated OPD module documentation in a.json to include comprehensive features and benefits.
- Added GetJinaApiKey function to retrieve Jina API key from environment variables.
- Modified RerankingRequestModel to use "jina-reranker-m0" as the default model and added returnDocuments parameter.
- Replaced AsyncTogether client with requests.Session for Jina API calls in RerankingService.
- Updated HandleKgExatrctProcessResponseModel to HandleChunkRelationExtractResponseModel and adjusted related models for chunk processing.
- Removed deprecated GragSystemPropts.py and added FileGragSystemPropts.py with updated prompt structure.
- Enhanced FileChunkGragService to handle questions and relations more effectively.
- Adjusted batch sizes and embedding processes for improved performance.